### PR TITLE
fix test that breaks if dates are ~1s different

### DIFF
--- a/test/multi-mount.js
+++ b/test/multi-mount.js
@@ -61,8 +61,8 @@ function req (url, headers, cb) {
       assert(Math.abs(new Date(res.headers.date).getTime() -
                       new Date(res.headers.date).getTime()) < 1000)
       // compare the headers minus the 'date' value
-      assert.deepEqual(Object.create(res.headers, { date: { value: '' } }),
-                       Object.create(prev.res.headers, { date: { value: '' } }))
+      res.headers.date = prev.res.headers.date = null
+      assert.deepEqual(res.headers, prev.res.headers)
       assert.equal('' + body, '' + prev.body)
       return cb(er, res, body)
     }


### PR DESCRIPTION
This is just a fix for tests failing on the machines I run them on; eventually, testing headers fails on a `deepEquals` because the `'date'` field shows a difference of 1 second.

Solution: test the date separately, make sure the difference between them is `<1000`ms (could be more I guess but this works for me), then mask out the `'date'` field for the `deepEquals`.
