### PR TITLE
handle paths properly in Windows

### DIFF
--- a/st.js
+++ b/st.js
@@ -169,7 +169,7 @@ Mount.prototype.getCacheOptions = function (opt) {
 
 // get a path from a url
 Mount.prototype.getPath = function (u) {
-  u = path.join('/', url.parse(u).pathname).replace(/\\/g, '/')
+  u = path.normalize(url.parse(u).pathname.replace(/^[\/\\]?/, '/')).replace(/\\/g, '/')
   if (u.indexOf(this.url) !== 0) return false;
 
   // /a/b/c mounted on /path/to/z/d/x

--- a/test/basic.js
+++ b/test/basic.js
@@ -49,6 +49,7 @@ var stExpect = fs.readFileSync(require.resolve('../st.js')).toString()
 test('simple request', function (t) {
   req('/test/st.js', function (er, res, body) {
     t.equal(res.statusCode, 200)
+    t.ok(/\/javascript$/.test(res.headers['content-type']))
     t.ok(res.headers.etag)
     stEtag = res.headers.etag
     t.equal(body.toString(), stExpect)


### PR DESCRIPTION
I'm having to deploy on Windows so I picked this one up. It's an odd one, but the summary is that doing a `path.join('/', '/foo/bar')` on windows results in the UNC path `'\\foo\bar\'` (even though just `'/foo'` is fine). Surprisingly this works out OK downstream _except_ for mime-type detection. `'/styles/foo.css'` ends up as `'/styles/foo.css/'` which doesn't get a mime-type, which isn't such a good thing.

My solution is to fix the path with `.replace()` to make sure it has a leading `'/'` and then do a `path.normalize()` on that (like `path.join()` does, so we're effectively synthesizing a join).

Added an extra test to make sure `'content-type'` comes out right, but it's not entirely necessary since other tests in _basic_ were failing on Windows. All pass after this change.
