### PR TITLE
Fix cli dot-arg-parsing

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -25,8 +25,8 @@ for (var i = 2; i < process.argv.length; i++) {
     case '--dot':
       dot = process.argv[++i]
       if (dot === undefined || dot === 'true') dot = true
-      if (dot === 'false') dot = false
-      if (dot.charAt(0) === '-') {
+      else if (dot === 'false') dot = false
+      else if (dot.charAt(0) === '-') {
         --i
         dot = true
       }


### PR DESCRIPTION
```
$ st -.

/usr/local/lib/node_modules/st/bin/server.js:29
      if (dot.charAt(0) === '-') {
              ^
TypeError: Object true has no method 'charAt'
    at Object.<anonymous> (/usr/local/lib/node_modules/st/bin/server.js:29:15)
    at Module._compile (module.js:449:26)
    at Object.Module._extensions..js (module.js:467:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.runMain (module.js:492:10)
    at process.startup.processNextTick.process._tickCallback (node.js:245:9)
```
