### PR TITLE
add output to CLI fixes #21

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -143,4 +143,4 @@ http.createServer(function (q, s) {
   s.end('not found')
 }).listen(port)
 
-console.log('listening at http://127.0.0.1:' + port);
+console.log('listening at http://127.0.0.1:' + port)


### PR DESCRIPTION
just writes to console log, but allows you to simply click the link from most terminal applications.
