### PR TITLE
-nc sets cache to false, proper no cache

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -123,9 +123,7 @@ var opt = {
 }
 
 if (cache === false) {
-  Object.keys(opt.cache).forEach(function (k) {
-    opt.cache[k].max = 0
-  })
+  opt.cache = false
 } else {
   if (age) {
     Object.keys(opt.cache).forEach(function (k) {


### PR DESCRIPTION
`-nc` doesn't do a full _no-cache_ job, set `opt.cache=false` to do the job properly.
