### PR TITLE
range request support

### DIFF
--- a/st.js
+++ b/st.js
@@ -526,9 +526,16 @@ function getRange (stat,req) {
   var start = 0, end = stat.size, status = 200
   if (typeof req.headers.range !== 'undefined') {
     var ranges = req.headers.range.replace('bytes=', '').split('-')
+    status = 206
     start = +ranges[0]
     end = +ranges[1]
-    status = 206
+    if (0 === ranges[0].length) { // bytes=-500
+      start = stat.size - end
+      end = stat.size - 1
+    }
+    if (0 === ranges[1].length) { // bytes=500-
+      end = stat.size - 1
+    }
     if (start > end) {
       status = 416
       start = 0

--- a/st.js
+++ b/st.js
@@ -525,7 +525,9 @@ function getRange (stat,req) {
   // detect range request
   var start = 0, end = stat.size, status = 200
   if (typeof req.headers.range !== 'undefined') {
-    var ranges = req.headers.range.replace('bytes=', '').split('-')
+    // not supported split byte-spec
+    var ranges = req.headers.range.replace('bytes=', '').split(',').shift()
+    ranges = ranges.split('-')
     status = 206
     start = +ranges[0]
     end = +ranges[1]

--- a/test/basic.js
+++ b/test/basic.js
@@ -124,11 +124,15 @@ test('space in filename', function (t) {
 })
 
 test('206 request', function (t) {
-  req('/test/st.js', {'range':'bytes=0-10', 'accept-encoding':'gzip'}, function (er, res, body) {
-    t.equal(res.statusCode, 206)
-    t.notEqual(res.headers['content-encoding'], 'gzip')
-    t.ok(body)
-    t.end()
+  fs.stat('../st.js', function(err, stats) {
+    req('/test/st.js', {'range':'bytes=0-10', 'accept-encoding':'gzip'}, function (er, res, body) {
+      t.equal(res.statusCode, 206)
+      t.equal(res.headers['content-length'], '11')
+      t.equal(res.headers['content-range'], 'bytes 0-10/' + stats.size)
+      t.notEqual(res.headers['content-encoding'], 'gzip')
+      t.ok(body)
+      t.end()
+    })
   })
 })
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -124,8 +124,9 @@ test('space in filename', function (t) {
 })
 
 test('206 request', function (t) {
-  fs.stat('../st.js', function(err, stats) {
-    req('/test/st.js', {'range':'bytes=0-10', 'accept-encoding':'gzip'}, function (er, res, body) {
+  fs.stat('./fixtures/stream.txt', function(err, stats) {
+    req('/test/test/fixtures/stream.txt', {'range':'bytes=0-10', 'accept-encoding':'gzip'}, function (er, res, body) {
+      t.equal(body.toString(), 'Lorem ipsum')
       t.equal(body.length, 11)
       t.equal(res.statusCode, 206)
       t.equal(res.headers['content-length'], '11')
@@ -137,11 +138,42 @@ test('206 request', function (t) {
   })
 })
 
+test('last bytes', function (t) {
+  fs.stat('./fixtures/stream.txt', function(err, stats) {
+    req('/test/test/fixtures/stream.txt', {'range':'bytes=-13', 'accept-encoding':'gzip'}, function (er, res, body) {
+      t.equal(body.length, 13)
+      t.equal(body.toString(), 'magna aliqua.')
+      t.equal(res.statusCode, 206)
+      t.equal(res.headers['content-length'], '13')
+      t.equal(res.headers['content-range'], 'bytes '+ (stats.size - 13) + '-' + (stats.size - 1) + '/' + stats.size)
+      t.notEqual(res.headers['content-encoding'], 'gzip')
+      t.ok(body)
+      t.end()
+    })
+  })
+})
+
+test('from bytes', function (t) {
+  fs.stat('./fixtures/stream.txt', function(err, stats) {
+    req('/test/test/fixtures/stream.txt', {'range':'bytes=111-', 'accept-encoding':'gzip'}, function (er, res, body) {
+      t.equal(body.length, 13)
+      t.equal(body.toString(), 'magna aliqua.')
+      t.equal(res.statusCode, 206)
+      t.equal(res.headers['content-length'], '13')
+      t.equal(res.headers['content-range'], 'bytes '+ (stats.size - 13) + '-' + (stats.size - 1) + '/' + stats.size)
+      t.notEqual(res.headers['content-encoding'], 'gzip')
+      t.ok(body)
+      t.end()
+    })
+  })
+})
+
 test('invalid range', function (t) {
-  req('/test/st.js', {'range':'bytes=10-0'}, function (er, res, body) {
+  req('/test/test/fixtures/stream.txt', {'range':'bytes=10-0'}, function (er, res, body) {
     t.equal(res.statusCode, 416)
     t.notEqual(res.headers['content-encoding'], 'gzip')
     t.ok(body)
     t.end()
   })
 })
+

--- a/test/basic.js
+++ b/test/basic.js
@@ -126,6 +126,7 @@ test('space in filename', function (t) {
 test('206 request', function (t) {
   fs.stat('../st.js', function(err, stats) {
     req('/test/st.js', {'range':'bytes=0-10', 'accept-encoding':'gzip'}, function (er, res, body) {
+      t.equal(body.length, 11)
       t.equal(res.statusCode, 206)
       t.equal(res.headers['content-length'], '11')
       t.equal(res.headers['content-range'], 'bytes 0-10/' + stats.size)

--- a/test/basic.js
+++ b/test/basic.js
@@ -122,3 +122,21 @@ test('space in filename', function (t) {
     t.end()
   })
 })
+
+test('206 request', function (t) {
+  req('/test/st.js', {'range':'bytes=0-10', 'accept-encoding':'gzip'}, function (er, res, body) {
+    t.equal(res.statusCode, 206)
+    t.notEqual(res.headers['content-encoding'], 'gzip')
+    t.ok(body)
+    t.end()
+  })
+})
+
+test('invalid range', function (t) {
+  req('/test/st.js', {'range':'bytes=10-0'}, function (er, res, body) {
+    t.equal(res.statusCode, 416)
+    t.notEqual(res.headers['content-encoding'], 'gzip')
+    t.ok(body)
+    t.end()
+  })
+})

--- a/test/fixtures/stream.txt
+++ b/test/fixtures/stream.txt
@@ -1,0 +1,1 @@
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.


### PR DESCRIPTION
set `streamOpt.start` and `streamOpt.end` from Range header val.
- correct range, return 206 (e.g. `bytes=0-1`)
- invalid range, return 416 (e.g. `bytes=10-0`)
- from/last range-spec, return 206 (e.g. `bytes=10-` or `bytes=-10`)
- over range, return 206 with `bytes=0-#{stat.size - 1}`
- gzip always off on range-request
- not supported split range-spec (e.g. `bytes=0-1,-1` or `bytes=500-600,601-999`)
