### PR TITLE
Fixed 'noCaching' typo. Changed 'maxSize' to 'maxAge'

### DIFF
--- a/st.js
+++ b/st.js
@@ -108,7 +108,7 @@ function Mount (opt) {
 // lru-cache doesn't like when max=0, so we just pretend
 // everything is really big.  kind of a kludge, but easiest way
 // to get it done
-var none = { max: 1, maxSize: 0, length: function() {
+var none = { max: 1, maxAge: null, length: function() {
   return Infinity
 }}
 var noCaching = {


### PR DESCRIPTION
The `opt` object is for `node-lru-cache`'s consumption. It does this check: `this._maxAge = options.maxAge || null`.  Since there is no `maxAge` property, `this._maxAge` is getting set to `null`. This is probably the intended effect of setting `maxSize: 0`.

The `maxAge` property could be removed all together since that's essentially the way its been working, but this fix makes it explicit that there is no `maxAge`. Besides there is no `maxSize`.
