### PR TITLE
Do not set headers in case of directory, no index and passthrough

### DIFF
--- a/st.js
+++ b/st.js
@@ -227,6 +227,11 @@ Mount.prototype.serve = function (req, res, next) {
         return this.error(er, res)
       }
 
+      if (stat.isDirectory() && next && this.opt.passthrough === true && this._index === false) {
+        end()
+        return next()
+      }
+
       var ims = req.headers['if-modified-since']
       if (ims) ims = new Date(ims).getTime()
       if (ims && ims >= stat.mtime.getTime()) {
@@ -248,9 +253,6 @@ Mount.prototype.serve = function (req, res, next) {
 
       if (stat.isDirectory()) {
         end()
-        if (next && this.opt.passthrough === true && this._index === false) {
-          return next()
-        }
         return this.index(p, req, res)
       }
 


### PR DESCRIPTION
When running _st_ as middleware with `next` function, `index: false`, and `passthrough: true`, still cache cache headers are being set. It shouldn't be the case as request is expected to be handled outside of _st_

Today I run into issues, when main page of my application was not refreshed by the browser, and user after login was still seing public page, it was caused by `Cache-control: public` (as set by _st_) and browser didn't try to refetch the page.
