### PR TITLE
Malformed URLs no longer cause a crash

### DIFF
--- a/st.js
+++ b/st.js
@@ -159,7 +159,13 @@ Mount.prototype.getPath = function (u) {
   u = path.normalize(url.parse(u).pathname.replace(/^[\/\\]?/, '/')).replace(/\\/g, '/')
   if (u.indexOf(this.url) !== 0) return false
 
-  u = decodeURIComponent(u)
+  try {
+    u = decodeURIComponent(u)
+  }
+  catch (e) {
+    // if decodeURIComponent failed, we weren't given a valid URL to begin with.
+    return false
+  }
 
   // /a/b/c mounted on /path/to/z/d/x
   // /a/b/c/d --> /path/to/z/d/x/d

--- a/test/basic.js
+++ b/test/basic.js
@@ -122,3 +122,10 @@ test('space in filename', function (t) {
     t.end()
   })
 })
+
+test('malformed URL', function (t) {
+  req('/test%2E%git', function (er, res, body) {
+    t.equal(res.statusCode, 404)
+    t.end()
+  })
+})


### PR DESCRIPTION
We're running `st` in production and had a bot hit our server with a bunch of bad URLs that caused st to crash. Here's the stack trace:

``` json
"stack": [
    "URIError: URI malformed",
    "    at decodeURIComponent (native)",
    "    at Mount.getPath (/opt/app/node_modules/st/st.js:162:7)",
    "    at Mount.serve (/opt/app/node_modules/st/st.js:190:16)",
    "    at dispatch (/opt/app/node_modules/union/lib/routing-stream.js:110:21)",
    "    at RoutingStream.route (/opt/app/node_modules/union/lib/routing-stream.js:121:5)",
    "    at g (events.js:180:16)",
    "    at EventEmitter.emit (events.js:117:20)",
    "    at IncomingMessage.Readable.pipe (_stream_readable.js:548:8)",
    "    at Server.requestHandler (/opt/app/node_modules/union/lib/core.js:50:9)",
    "    at Server.EventEmitter.emit (events.js:98:17)"
  ]
```

The problem appears to be that a malformed URL causes an uncaught exception when `decodeURIComponent` fails. This solves the problem simply with a try/catch.
