### PR TITLE
Don't send headers on passthrough

### DIFF
--- a/st.js
+++ b/st.js
@@ -256,19 +256,21 @@ Mount.prototype.serve = function (req, res, next) {
         return end()
       }
 
-      res.setHeader('cache-control', 'public')
-      res.setHeader('last-modified', stat.mtime.toUTCString())
-      res.setHeader('etag', etag)
-
       if (stat.isDirectory()) {
         end()
         if (next && this.opt.passthrough === true && this._index === false) {
           return next()
         }
-        return this.index(p, req, res)
       }
 
-      return this.file(p, fd, stat, etag, req, res, end)
+      // only set headers once we're sure we'll be serving this request
+      res.setHeader('cache-control', 'public')
+      res.setHeader('last-modified', stat.mtime.toUTCString())
+      res.setHeader('etag', etag)
+
+      return stat.isDirectory()
+        ? this.index(p, req, res)
+        : this.file(p, fd, stat, etag, req, res, end)
     }.bind(this))
   }.bind(this))
 

--- a/test/passthrough.js
+++ b/test/passthrough.js
@@ -54,3 +54,29 @@ test('return error if passthrough is not set', function (t) {
     t.end()
   })
 })
+
+test('does not set headers if passthrough is set', function (t){
+  var req = { method: 'GET', url: '/doesnotexist.txt', headers: {} }
+  var res = {
+    error: function () {
+      t.end()
+    },
+    _headers: [],
+    setHeader: function (header) {
+      res._headers.push(header)
+    },
+    end: function () {}
+  }
+  t.plan(2)
+  mount(req, res, function () {
+
+    t.notOk(res._headers.length, 'headers are not set on a non-existant file')
+    req.url='/';
+
+    mount(req, res, function () {
+      console.error(res._headers)
+      t.notOk(res._headers.length, 'headers are not set with no index')
+      t.end()
+    })
+  })
+})


### PR DESCRIPTION
Prevents aggressive cache headers from being set when st won't serve the route.
