### PR TITLE
Leverage browser caching by specifying max-age

### DIFF
--- a/st.js
+++ b/st.js
@@ -92,6 +92,8 @@ function Mount (opt) {
   this._index = opt.index === false ? false
               : typeof opt.index === 'string' ? opt.index
               : true
+  this._cacheControl = opt.cache === false ? 'public'
+                     : 'public, max-age=' + opt.cache.content.maxAge / 1000
   this.fdman = FD()
 
   // cache basically everything
@@ -284,7 +286,7 @@ Mount.prototype.serve = function (req, res, next) {
       }
 
       // only set headers once we're sure we'll be serving this request
-      res.setHeader('cache-control', 'public')
+      res.setHeader('cache-control', this._cacheControl)
       res.setHeader('last-modified', stat.mtime.toUTCString())
       res.setHeader('etag', etag)
 


### PR DESCRIPTION
I've noticed that adding a `max-age` value to `cache-control` header results in a much better real-life behaviour and yields a better results in speed test analysing tools such as Google's [PageSpeed Insights](https://developers.google.com/speed/pagespeed/insights/) or [Pingdom Tools](http://tools.pingdom.com/fpt/).

Even though requests to cached resources are quickly responded with `304`, adding a `max-age` value results in **less requests** being made to the server.

Ideally we would need to have a separate `browser.axAge` cache option, but it somehow seems logical to assimilate it with `content.maxAge`...

What do you think?
