### PR TITLE
Allowing gzip compression to be disabled by setting gzip: false

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ var mount = st({
 
   passthrough: true, // calls next/returns instead of returning a 404 error
   passthrough: false, // returns a 404 when a file or an index is not found
+
+  gzip: true, // default: compresses the response with gzip compression
+  gzip: false, // does not compress the response, even if client accepts gzip
 })
 
 // with bare node.js
@@ -225,6 +228,10 @@ this utility will use a bit more memory than the cache.content.max and
 cache.index.max bytes would seem to allow.  This will be less than
 double, and usually insignificant for normal web assets, but is
 important to consider if memory is at a premium.
+
+Gzip compression can be disabled by setting `gzip: false` on the options passed 
+into `st()`. This is useful if your application already handles gzipping
+responses by other means.
 
 ## Filtering Output
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -16,9 +16,12 @@ var opts = util._extend({
   url: '/test'
 }, global.options || {})
 
+var stExpect = fs.readFileSync(require.resolve('../st.js')).toString()
+
 var mount = st(opts)
 exports.mount = mount
 exports.req = req
+exports.stExpect = stExpect
 
 function req (url, headers, cb) {
   if (typeof headers === 'function') cb = headers, headers = {}
@@ -45,7 +48,6 @@ tap.tearDown(function() {
 
 
 var stEtag
-var stExpect = fs.readFileSync(require.resolve('../st.js')).toString()
 test('simple request', function (t) {
   req('/test/st.js', function (er, res, body) {
     t.equal(res.statusCode, 200)
@@ -65,18 +67,20 @@ test('304 request', function (t) {
   })
 })
 
-test('gzip', function (t) {
-  req('/test/st.js', {'accept-encoding':'gzip'},
-      function (er, res, body) {
-    t.equal(res.statusCode, 200)
-    t.equal(res.headers['content-encoding'], 'gzip')
-    zlib.gunzip(body, function (er, body) {
-      if (er) throw er;
-      t.equal(body.toString(), stExpect)
-      t.end()
+if (opts.gzip !== false) {
+  test('gzip', function (t) {
+    req('/test/st.js', {'accept-encoding':'gzip'},
+        function (er, res, body) {
+      t.equal(res.statusCode, 200)
+      t.equal(res.headers['content-encoding'], 'gzip')
+      zlib.gunzip(body, function (er, body) {
+        if (er) throw er;
+        t.equal(body.toString(), stExpect)
+        t.end()
+      })
     })
   })
-})
+}
 
 test('multiball!', function (t) {
   var n = 6

--- a/test/no-cache.js
+++ b/test/no-cache.js
@@ -10,7 +10,6 @@ var mount = basic.mount
 
 // additional tests to ensure that it's actually not caching.
 var test = require('tap').test
-var port = process.env.PORT || 1337
 
 test('all caches should be empty', function(t) {
   t.same(mount._this.cache.fd._cache.dump(), {})

--- a/test/no-gzip.js
+++ b/test/no-gzip.js
@@ -1,0 +1,23 @@
+// turn off gzip compression
+global.options = {
+  gzip: false
+}
+
+var basic = require('./basic.js')
+var req = basic.req
+var mount = basic.mount
+var stExpect = basic.stExpect
+
+// additional test to ensure that it's actually not gzipping
+var test = require('tap').test
+
+test('does not gzip the response', function(t) {
+  req('/test/st.js', {'accept-encoding':'gzip'},
+      function (er, res, body) {
+    t.equal(res.statusCode, 200)
+    t.notOk(res.headers['content-encoding'])
+    t.equal(body.toString(), stExpect)
+    t.end()
+  })
+})
+


### PR DESCRIPTION
This pull request allows gzip compression to be skipped by setting a `gzip` option to `false`
### Why I needed this

My app is based around Restify, which provides its own `gzipResponse` middleware. This middleware gzips all responses blindly. Restify can also serve static content, but its static content serving is very primitive. I wanted to use st for static content, but still allow `gzipResponse` to gzip everything. Without this setting, static content would get gzipped twice.

It is simpler to set up my static endpoints and hand them off to st, than have gzipResponse try and figure out when it should or should not compress.

I'm not sure if this fits your vision for st, but I figured I send a pull request in case it does.
