### PR TITLE
Fix no cache option

### DIFF
--- a/st.js
+++ b/st.js
@@ -104,7 +104,7 @@ function Mount (opt) {
     content: AC(c.content)
   }
 
-  this._cacheControl = opt.cache === false ? 'public'
+  this._cacheControl = opt.cache === false ? 'no-cache'
                      : 'public, max-age=' + c.content.maxAge / 1000
 }
 


### PR DESCRIPTION
In case of `cache: false` what should be set is`cache-control: no-cache`, instead `cache-control: public` is set, and that turns on even more aggressive caching than default `cache-control: max-age=600`
