### PR TITLE
Add an option to disable cache control headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ var mount = st({
     content: {
       max: 1024*1024*64, // how much memory to use on caching contents
       maxAge: 1000 * 60 * 10, // how long to cache contents for
+                              // if `false` does not set cache control headers
     },
 
     index: { // irrelevant if not using index:true

--- a/st.js
+++ b/st.js
@@ -104,6 +104,7 @@ function Mount (opt) {
     content: AC(c.content)
   }
 
+  this._cacheEnabled = c.content.maxAge === false ? false : true
   this._cacheControl = opt.cache === false ? 'public'
                      : 'public, max-age=' + c.content.maxAge / 1000
 }
@@ -287,7 +288,7 @@ Mount.prototype.serve = function (req, res, next) {
       }
 
       // only set headers once we're sure we'll be serving this request
-      res.setHeader('cache-control', this._cacheControl)
+      this._cacheEnabled && res.setHeader('cache-control', this._cacheControl)
       res.setHeader('last-modified', stat.mtime.toUTCString())
       res.setHeader('etag', etag)
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -116,7 +116,12 @@ test('multiball!', function (t) {
     var cc = 'public, max-age=600'
     if (opts.cache === false)
       cc = 'public'
-    t.equal(res.headers['cache-control'], cc)
+
+    if (opts.cache && opts.cache.content && opts.cache.content.maxAge === false) {
+      t.notOk(res.headers['cache-control'])
+    } else {
+      t.equal(res.headers['cache-control'], cc)
+    }
 
     if (--n === 0)
       t.end()

--- a/test/no-content-maxage.js
+++ b/test/no-content-maxage.js
@@ -1,0 +1,10 @@
+global.options = {
+  cache: {
+    content: {
+      maxAge: false
+    }
+  }
+}
+
+// otherwise just the same as basic.
+require('./basic.js')


### PR DESCRIPTION
While the options `st` offers for cache control are good enough for most use-cases, there are some that it is not able to handle -- for example, setting any sort of custom header here other than `public` or `public; maxAge=X`. Since `st` ends the request after serving a file, the user has no way to customize cache headers any further after `st` runs, and if the headers are set before, `st` clobbers them before serving the file.

This PR makes it such that if you set `cache.content.maxAge` to `false`, it does not set cache control headers, allowing the user to set them beforehand without the headers being overwritten by `st`.

I'm not totally familiar with your style of writing js or testing, but I did my best to conform to both, let me know if there are any changes I can make to improve this, or if there's another implementation you'd prefer and happy to modify!
