### PR TITLE
Better cache control

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ var mount = st({
     content: {
       max: 1024*1024*64, // how much memory to use on caching contents
       maxAge: 1000 * 60 * 10, // how long to cache contents for
+                              // if `false` does not set cache control headers
     },
 
     index: { // irrelevant if not using index:true

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ var mount = st({
       max: 1024*1024*64, // how much memory to use on caching contents
       maxAge: 1000 * 60 * 10, // how long to cache contents for
                               // if `false` does not set cache control headers
+      cacheControl: 'public, max-age=600' // to set an explicit cache-control
+                                          // header value
     },
 
     index: { // irrelevant if not using index:true

--- a/st.js
+++ b/st.js
@@ -108,9 +108,20 @@ function Mount (opt) {
   this._cacheControl = opt.cache === false ? 'no-cache'
 =======
   this._cacheEnabled = c.content.maxAge === false ? false : true
+<<<<<<< HEAD
   this._cacheControl = opt.cache === false ? 'public'
 >>>>>>> add an option to disable cache control headers
                      : 'public, max-age=' + c.content.maxAge / 1000
+=======
+  this._cacheControl =
+    c.content.maxAge === false
+      ? undefined
+      : typeof c.content.cacheControl == 'string'
+        ? c.content.cacheControl
+        : opt.cache === false
+          ? 'public'
+          : 'public, max-age=' + (c.content.maxAge / 1000)
+>>>>>>> more flexibility around cache-control
 }
 
 // lru-cache doesn't like when max=0, so we just pretend
@@ -292,7 +303,8 @@ Mount.prototype.serve = function (req, res, next) {
       }
 
       // only set headers once we're sure we'll be serving this request
-      this._cacheEnabled && res.setHeader('cache-control', this._cacheControl)
+      if (!res.getHeader('cache-control'))
+        res.setHeader('cache-control', this._cacheControl)
       res.setHeader('last-modified', stat.mtime.toUTCString())
       res.setHeader('etag', etag)
 

--- a/st.js
+++ b/st.js
@@ -104,24 +104,14 @@ function Mount (opt) {
     content: AC(c.content)
   }
 
-<<<<<<< HEAD
-  this._cacheControl = opt.cache === false ? 'no-cache'
-=======
-  this._cacheEnabled = c.content.maxAge === false ? false : true
-<<<<<<< HEAD
-  this._cacheControl = opt.cache === false ? 'public'
->>>>>>> add an option to disable cache control headers
-                     : 'public, max-age=' + c.content.maxAge / 1000
-=======
   this._cacheControl =
     c.content.maxAge === false
       ? undefined
       : typeof c.content.cacheControl == 'string'
         ? c.content.cacheControl
         : opt.cache === false
-          ? 'public'
+          ? 'no-cache'
           : 'public, max-age=' + (c.content.maxAge / 1000)
->>>>>>> more flexibility around cache-control
 }
 
 // lru-cache doesn't like when max=0, so we just pretend

--- a/st.js
+++ b/st.js
@@ -104,7 +104,12 @@ function Mount (opt) {
     content: AC(c.content)
   }
 
+<<<<<<< HEAD
   this._cacheControl = opt.cache === false ? 'no-cache'
+=======
+  this._cacheEnabled = c.content.maxAge === false ? false : true
+  this._cacheControl = opt.cache === false ? 'public'
+>>>>>>> add an option to disable cache control headers
                      : 'public, max-age=' + c.content.maxAge / 1000
 }
 
@@ -287,7 +292,7 @@ Mount.prototype.serve = function (req, res, next) {
       }
 
       // only set headers once we're sure we'll be serving this request
-      res.setHeader('cache-control', this._cacheControl)
+      this._cacheEnabled && res.setHeader('cache-control', this._cacheControl)
       res.setHeader('last-modified', stat.mtime.toUTCString())
       res.setHeader('etag', etag)
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -116,7 +116,7 @@ test('multiball!', function (t) {
     t.equal(res.statusCode, 200)
 
     if (opts.cache === false)
-      t.equal(res.headers['cache-control'], 'public')
+      t.equal(res.headers['cache-control'], 'no-cache')
     else if (opts.cache && opts.cache.content && opts.cache.content.maxAge === false)
       t.notOk(res.headers['cache-control'])
     else if (opts.cache && opts.cache.content && opts.cache.content.cacheControl)

--- a/test/basic.js
+++ b/test/basic.js
@@ -115,8 +115,13 @@ test('multiball!', function (t) {
     t.equal(res.statusCode, 200)
     var cc = 'public, max-age=600'
     if (opts.cache === false)
-      cc = 'no-cache'
-    t.equal(res.headers['cache-control'], cc)
+      cc = 'public'
+
+    if (opts.cache && opts.cache.content && opts.cache.content.maxAge === false) {
+      t.notOk(res.headers['cache-control'])
+    } else {
+      t.equal(res.headers['cache-control'], cc)
+    }
 
     if (--n === 0)
       t.end()

--- a/test/basic.js
+++ b/test/basic.js
@@ -112,16 +112,17 @@ test('multiball!', function (t) {
   function then2 (er, res, body) {
     if (er)
       throw er
-    t.equal(res.statusCode, 200)
-    var cc = 'public, max-age=600'
-    if (opts.cache === false)
-      cc = 'public'
 
-    if (opts.cache && opts.cache.content && opts.cache.content.maxAge === false) {
+    t.equal(res.statusCode, 200)
+
+    if (opts.cache === false)
+      t.equal(res.headers['cache-control'], 'public')
+    else if (opts.cache && opts.cache.content && opts.cache.content.maxAge === false)
       t.notOk(res.headers['cache-control'])
-    } else {
-      t.equal(res.headers['cache-control'], cc)
-    }
+    else if (opts.cache && opts.cache.content && opts.cache.content.cacheControl)
+      t.equal(res.headers['cache-control'], opts.cache.content.cacheControl)
+    else
+      t.equal(res.headers['cache-control'], 'public, max-age=600')
 
     if (--n === 0)
       t.end()

--- a/test/explicit-cache-control.js
+++ b/test/explicit-cache-control.js
@@ -1,0 +1,10 @@
+global.options = {
+  cache: {
+    content: {
+      cacheControl: 'pubic, marx-aged=-100'
+    }
+  }
+}
+
+// otherwise just the same as basic.
+require('./basic.js')

--- a/test/no-content-maxage.js
+++ b/test/no-content-maxage.js
@@ -1,0 +1,10 @@
+global.options = {
+  cache: {
+    content: {
+      maxAge: false
+    }
+  }
+}
+
+// otherwise just the same as basic.
+require('./basic.js')

--- a/test/preset-cache-control.js
+++ b/test/preset-cache-control.js
@@ -1,0 +1,61 @@
+var st = require('../st.js')
+var tap = require('tap')
+var test = require('tap').test
+var util = require('util')
+var path = require('path')
+var http = require('http')
+var request = require('request')
+var port = process.env.PORT || 1337
+
+var opts = util._extend({
+  index: false,
+  path: path.dirname(__dirname),
+  url: '/test'
+}, global.options || {})
+
+var mount = st(opts)
+var server
+var cacheControl = null
+
+function req (url, headers, cb) {
+  if (typeof headers === 'function') cb = headers, headers = {}
+  request({ encoding: null,
+            url: 'http://localhost:' + port + url,
+            headers: headers }, cb)
+}
+
+tap.test('setup', function (t) {
+  server = http.createServer(function (req, res) {
+    if (cacheControl)
+      res.setHeader('cache-control', cacheControl)
+    if (!mount(req, res)) {
+      res.statusCode = 404
+      return res.end('Not a match: ' + req.url)
+    }
+  }).listen(port, function () {
+    t.pass('listening')
+    t.end()
+  })
+})
+
+tap.tearDown(function() {
+  server.close()
+})
+
+tap.test('simple request', function (t) {
+  cacheControl = null
+  req('/test/st.js', function (er, res, body) {
+    t.ifError(er)
+    t.equal(res.headers['cache-control'], 'public, max-age=600')
+    t.end()
+  })
+})
+
+tap.test('pre-set cache-control', function (t) {
+  cacheControl = 'I\'m so excited, and I just can\'t hide it'
+  req('/test/st.js', function (er, res, body) {
+    t.ifError(er)
+    t.equal(res.headers['cache-control'], cacheControl)
+    t.end()
+  })
+})


### PR DESCRIPTION
Pulls in the `maxAge===false` PR from @jenius #43 and adds the ability to explicitly set `'cache-control'` with an `options.content.cacheControl` string option.

Also checks if `'cache-control'` has already been set, if so, leave it alone.
