### PR TITLE
Content-Type default to UTF-8

### DIFF
--- a/st.js
+++ b/st.js
@@ -348,7 +348,7 @@ Mount.prototype.autoindex = function (p, req, res) {
     if (er) return this.error(er, res)
 
     res.statusCode = 200
-    res.setHeader('content-type', 'text/html')
+    res.setHeader('content-type', 'text/html; charset=UTF-8')
     res.setHeader('content-length', html.length)
     res.end(html)
   }.bind(this))

--- a/st.js
+++ b/st.js
@@ -359,6 +359,11 @@ Mount.prototype.file = function (p, fd, stat, etag, req, res, end) {
   var key = stat.size + ':' + etag
 
   var mt = mime.lookup(path.extname(p))
+
+  if (mt === 'text/html') {
+    mt += '; charset=UTF-8';
+  }
+
   if (mt !== 'application/octet-stream') {
     res.setHeader('content-type', mt)
   }


### PR DESCRIPTION
Hey,

I detected a little problem while using st on German content. The 
charset was missing on the content-type. I compared an express
solution with st and this was the difference. Unfortunately st got no
option to control this but I think UTF-8 as default is pretty useful.

The current implementation works so far. 
