### PR TITLE
Fix passthrough on non-existing file edge cases

### DIFF
--- a/st.js
+++ b/st.js
@@ -250,7 +250,9 @@ Mount.prototype.serve = function (req, res, next) {
     // fall through to that.  otherwise, we already returned true,
     // send an error.
     if (er) {
-      if (this.opt.passthrough === true && er.code === 'ENOENT' && next)
+      if (this.opt.passthrough === true &&
+        ( er.code === 'ENOENT' || er.code === 'ENOTDIR' )
+        && next)
         return next()
       return this.error(er, res)
     }


### PR DESCRIPTION
A request does not "passthrough" (when using `opt.passthrough`) when the file is non-existent, providing the folder of that file is an existing regular file.
For example, with a folder containing `image.jpg`, trying to access `image.jpg/thisdoesnotexist` will fire an error instead of passing the request over to the next middleware.
This pull request fixes this by adding the missing error code `ENOTDIR`.
