### PR TITLE
Added test for a path containing '..'

### DIFF
--- a/st.js
+++ b/st.js
@@ -572,11 +572,19 @@ Mount.prototype._loadStat = function (key, cb) {
   }
 }
 
-Mount.prototype._loadContent = function () {
+Mount.prototype._loadContent = function (key, cb) {
   // this function should never be called.
   // we check if the thing is in the cache, and if not, stream it in
   // manually.  this.cache.content.get() should not ever happen.
-  throw new Error('This should not ever happen')
+  var c = this.cache.content._cache[key]
+  var h = this.cache.content.has(key)
+
+  throw new Error('This should not ever happen' +
+    '\ncache: ' + c +
+    '\nkey: ' + key +
+    '\nhas: ' + h +
+    '\nexpected: undefined, ?, true'
+  )
 }
 
 function getEtag (s) {

--- a/st.js
+++ b/st.js
@@ -368,9 +368,11 @@ Mount.prototype.file = function (p, fd, stat, etag, req, res, end) {
 
   // only use the content cache if it will actually fit there.
   if (this.cache.content.has(key)) {
+    console.log('has: ' + key)
     end()
     this.cachedFile(p, stat, etag, req, res)
   } else {
+    console.log('does not have: ' + key)
     this.streamFile(p, fd, stat, etag, req, res, end)
   }
 }
@@ -585,6 +587,10 @@ Mount.prototype._loadContent = function (key, cb) {
     '\nhas: ' + h +
     '\nexpected: undefined, ?, true'
   )
+
+  // cache: undefined
+  // key: 1192:"64769-5426-1431111370000"
+  // has: false
 }
 
 function getEtag (s) {

--- a/stack-trace.txt
+++ b/stack-trace.txt
@@ -1,0 +1,14 @@
+/usr/local/lib/node_modules/st/st.js:579
+  throw new Error('This should not ever happen')
+        ^
+Error: This should not ever happen
+    at Mount._loadContent (/usr/local/lib/node_modules/st/st.js:579:9)
+    at AsyncCache.get (/usr/local/lib/node_modules/st/node_modules/async-cache/ac.js:48:8)
+    at Mount.cachedFile (/usr/local/lib/node_modules/st/st.js:382:22)
+    at Mount.file (/usr/local/lib/node_modules/st/st.js:372:10)
+    at Mount.<anonymous> (/usr/local/lib/node_modules/st/st.js:308:16)
+    at /usr/local/lib/node_modules/st/node_modules/async-cache/ac.js:58:7
+    at Array.forEach (native)
+    at AsyncCache.<anonymous> (/usr/local/lib/node_modules/st/node_modules/async-cache/ac.js:57:9)
+    at Mount.<anonymous> (/usr/local/lib/node_modules/st/st.js:568:7)
+    at Object.oncomplete (evalmachine.<anonymous>:107:15)

--- a/test/parent-path.js
+++ b/test/parent-path.js
@@ -1,0 +1,8 @@
+var path = require('path')
+
+global.options = {
+  path: path.dirname(__filename) + '/..'
+}
+
+// otherwise just the same as basic.
+require('./basic.js')

--- a/test/passthrough.js
+++ b/test/passthrough.js
@@ -74,7 +74,6 @@ test('does not set headers if passthrough is set', function (t){
     req.url='/';
 
     mount(req, res, function () {
-      console.error(res._headers)
       t.notOk(res._headers.length, 'headers are not set with no index')
       t.end()
     })


### PR DESCRIPTION
This test ensures that a path containing `'..'` is allowed in the `path` option.

Also removed a stray console.error() in `test/passthrough.js`.