### PR TITLE
Static gzip

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,14 @@ Gzip compression can be disabled by setting `gzip: false` on the options passed
 into `st()`. This is useful if your application already handles gzipping
 responses by other means.
 
+It's also possible to pre gzip files to front load the gzipping effort (or if
+you want to use more aggressive gzipping like
+[Zopfli](https://github.com/google/zopfli)). By setting `staticGzip: true` in
+the options, when a request is received st will look for the filename with a
+`.gz` suffix, and if it is found then those contents will be used instead
+(except for non-gzip requests). The statically gzipped contents will also be
+used for the cache as appropriate.
+
 ## Filtering Output
 
 If you want to do some fancy stuff to the file before sending it, you
@@ -244,6 +252,9 @@ object before passing it to the mount function.
 
 This is useful if you want to get the benefits of caching and gzipping
 and such, but serve stylus files as css, for example.
+
+When a statically gzipped file is encountered, this filter won't be applied. So
+don't pre-gzip files you want to apply filters to (or don't use static gzipping).
 
 ## Security Status
 

--- a/bin/server.js
+++ b/bin/server.js
@@ -8,6 +8,7 @@ var dot = false
 var index = true
 var cache = true
 var age = null
+var staticGzip = false
 
 for (var i = 2; i < process.argv.length; i++) {
   switch (process.argv[i]) {
@@ -71,6 +72,17 @@ for (var i = 2; i < process.argv.length; i++) {
       }
       age = +age
       break
+
+    case '-s':
+    case '--static-gzip':
+      staticGzip = true
+      break
+
+    case '-ns':
+    case '--no-static-gzip':
+      staticGzip = false
+      break
+
   }
 }
 
@@ -113,6 +125,7 @@ var opt = {
   path: dir,
   index: index,
   dot: dot,
+  staticGzip: staticGzip,
   cache: {
     fd: {},
     stat: {},

--- a/st.js
+++ b/st.js
@@ -479,7 +479,8 @@ Mount.prototype.streamFile = function (p, fd, stat, etag, req, res, end) {
       gzbufs = bl(collectEnd)
       if(this.opt.staticGzip) {
         gzipFileStream.on('error', function(e) {
-          noGzipFileStream.pipe(gzstr).pipe(gzbufs)
+          // Data is already in gzstr if it was a gzip request (because of the error handler when sending to the client)
+          ( gz ? gzstr : noGzipFileStream.pipe(gzstr) ).pipe(gzbufs)
           if(e.code == 'ENOENT')
             return
           console.error('Error writing gzipped file to cache %s.gz fd=%d\n%s', p, fd, e.stack || e.message)

--- a/st.js
+++ b/st.js
@@ -221,8 +221,7 @@ Mount.prototype.serve = function (req, res, next) {
   }
 
   // querystrings are of no concern to us
-  if (!req.sturl)
-    req.sturl = url.parse(req.url).pathname
+  req.sturl = url.parse(req.url).pathname
 
   var p = this.getPath(req.sturl)
 

--- a/st.js
+++ b/st.js
@@ -165,8 +165,7 @@ Mount.prototype.getCacheOptions = function (opt) {
 }
 
 // get a path from a url
-Mount.prototype.getPath = function (u) {
-  var p = url.parse(u).pathname
+Mount.prototype.getPath = function (p) {
 
   // Encoded dots are dots
   p = p.replace(/%2e/ig, '.')

--- a/st.js
+++ b/st.js
@@ -437,7 +437,7 @@ Mount.prototype.streamFile = function (p, fd, stat, etag, req, res, end) {
           killConnection(p + '.gz')(e)
         }
       })
-      gzipFileStream.on('readable', function() {
+      gzipFileStream.once('readable', function() {
         gzipFileStream.pipe(res)
       })
     } else {
@@ -484,7 +484,7 @@ Mount.prototype.streamFile = function (p, fd, stat, etag, req, res, end) {
             return
           console.error('Error writing gzipped file to cache %s.gz fd=%d\n%s', p, fd, e.stack || e.message)
         })
-        gzipFileStream.on('readable', function() {
+        gzipFileStream.once('readable', function() {
           gzipFileStream.pipe(gzbufs)
         })
       } else {

--- a/test/static-gzip.js
+++ b/test/static-gzip.js
@@ -1,4 +1,4 @@
-// turn off gzip compression
+// turn on static gzip compression
 global.options = {
   staticGzip: true
 }
@@ -10,13 +10,12 @@ var req = basic.req
 var mount = basic.mount
 var stExpect = basic.stExpect
 
-// additional test to ensure that it's actually not gzipping
+// test to ensure that the request returns the statically gzipped contents
 var test = require('tap').test
 
 test('gzip-static', function (t) {
   zlib.gzip(stExpect, function(er, gzipped) {
     if (er) throw er;
-    process.stdout.write(gzipped.toString())
     fs.writeFile('../tmp.txt.gz', gzipped, function(er) {
       fs.writeFile('../tmp.txt', 'this shouldn\'t be returned', function(er) {
         if (er) throw er;

--- a/test/static-gzip.js
+++ b/test/static-gzip.js
@@ -1,0 +1,42 @@
+// turn off gzip compression
+global.options = {
+  staticGzip: true
+}
+
+var fs = require('fs')
+var zlib = require('zlib')
+var basic = require('./basic.js')
+var req = basic.req
+var mount = basic.mount
+var stExpect = basic.stExpect
+
+// additional test to ensure that it's actually not gzipping
+var test = require('tap').test
+
+test('gzip-static', function (t) {
+  zlib.gzip(stExpect, function(er, gzipped) {
+    if (er) throw er;
+    process.stdout.write(gzipped.toString())
+    fs.writeFile('../tmp.txt.gz', gzipped, function(er) {
+      fs.writeFile('../tmp.txt', 'this shouldn\'t be returned', function(er) {
+        if (er) throw er;
+        req('/test/tmp.txt', {'accept-encoding':'gzip'},
+            function (er, res, body) {
+          t.equal(res.statusCode, 200)
+          t.equal(res.headers['content-encoding'], 'gzip')
+          zlib.gunzip(body, function (er, body) {
+            if (er) throw er;
+            t.equal(body.toString(), stExpect)
+            fs.unlink('../tmp.txt.gz', function(er) {
+              if (er) throw er;
+              fs.unlink('../tmp.txt', function(er) {
+                if (er) throw er;
+                t.end()
+              })
+            })
+          })
+        })
+      })
+    })
+  })
+})

--- a/test/static-gzip.js
+++ b/test/static-gzip.js
@@ -10,27 +10,33 @@ var req = basic.req
 var mount = basic.mount
 var stExpect = basic.stExpect
 
-// test to ensure that the request returns the statically gzipped contents
 var test = require('tap').test
 
-test('gzip-static', function (t) {
-  zlib.gzip(stExpect, function(er, gzipped) {
-    if (er) throw er;
-    fs.writeFile('../tmp.txt.gz', gzipped, function(er) {
-      fs.writeFile('../tmp.txt', 'this shouldn\'t be returned', function(er) {
-        if (er) throw er;
-        req('/test/tmp.txt', {'accept-encoding':'gzip'},
-            function (er, res, body) {
-          t.equal(res.statusCode, 200)
-          t.equal(res.headers['content-encoding'], 'gzip')
-          zlib.gunzip(body, function (er, body) {
-            if (er) throw er;
-            t.equal(body.toString(), stExpect)
-            fs.unlink('../tmp.txt.gz', function(er) {
+zlib.gzip(stExpect, function(er, gzipped) {
+  if (er) throw er;
+  fs.writeFile('../st.js.gz', gzipped, function(er) {
+
+    // test to ensure that the request returns the statically gzipped contents
+    test('gzip-static', function (t) {
+      fs.writeFile('../tmp.txt.gz', gzipped, function(er) {
+        fs.writeFile('../tmp.txt', 'this shouldn\'t be returned', function(er) {
+          if (er) throw er;
+          req('/test/tmp.txt', {'accept-encoding':'gzip'},
+              function (er, res, body) {
+            t.equal(res.statusCode, 200)
+            t.equal(res.headers['content-encoding'], 'gzip')
+            zlib.gunzip(body, function (er, body) {
               if (er) throw er;
-              fs.unlink('../tmp.txt', function(er) {
+              t.equal(body.toString(), stExpect)
+              fs.unlink('../tmp.txt.gz', function(er) {
                 if (er) throw er;
-                t.end()
+                fs.unlink('../tmp.txt', function(er) {
+                  if (er) throw er;
+                  fs.unlink('../st.js.gz', function(er) {
+                    if (er) throw er;
+                    t.end()
+                  })
+                })
               })
             })
           })

--- a/test/static-gzip.js
+++ b/test/static-gzip.js
@@ -14,27 +14,27 @@ var stExpect = basic.stExpect
 var test = require('tap').test
 
 zlib.gzip(stExpect, function(er, gzipped) {
-  if (er) throw er;
+  if (er) throw er
   fs.writeFile('../st.js.gz', gzipped, function(er) {
 
     // test to ensure that the request returns the statically gzipped contents
     test('gzip-static', function (t) {
       fs.writeFile('../tmp.txt.gz', gzipped, function(er) {
         fs.writeFile('../tmp.txt', 'this shouldn\'t be returned', function(er) {
-          if (er) throw er;
+          if (er) throw er
           req('/test/tmp.txt', {'accept-encoding':'gzip'},
               function (er, res, body) {
             t.equal(res.statusCode, 200)
             t.equal(res.headers['content-encoding'], 'gzip')
             zlib.gunzip(body, function (er, body) {
-              if (er) throw er;
+              if (er) throw er
               t.equal(body.toString(), stExpect)
               fs.unlink('../tmp.txt.gz', function(er) {
-                if (er) throw er;
+                if (er) throw er
                 fs.unlink('../tmp.txt', function(er) {
-                  if (er) throw er;
+                  if (er) throw er
                   fs.unlink('../st.js.gz', function(er) {
-                    if (er) throw er;
+                    if (er) throw er
                     t.end()
                   })
                 })

--- a/test/static-gzip.js
+++ b/test/static-gzip.js
@@ -1,6 +1,7 @@
 // turn on static gzip compression
 global.options = {
-  staticGzip: true
+  staticGzip: true,
+  gzip: true
 }
 
 var fs = require('fs')


### PR DESCRIPTION
Bit of an RFC pull request...

This PR adds support for serving pregzipped files in response to requests; eg /index.html will be served the file /index.html.gz if the client accepts gzip responses, and the file exists. If the .gz file doesn't exist, then the original file is compressed and sent - as before.

The cache is filled with the gzipped file if found.

Some other static gzipping implementations check things like timestamps to try and ensure that the .gz file and the requested file are the same thing, however this implementation doesn't do that...

I'm not sure if this is the best implementation; but it felt the least invasive, and seems to work - hence I went with it :-p

Happy to tweak :-) For now I just wanted to make the PR to see if it's something that could be considered for inclusion :-) (Before then considering more polish etc)

(Ps, also happy to squash the commits or anything too :-) )
