### PR TITLE
Fix `none` resolution

### DIFF
--- a/st.js
+++ b/st.js
@@ -133,7 +133,7 @@ Mount.prototype.getCacheOptions = function (opt) {
   var o = opt.cache
     , set = function (key) {
         return o[key] === false
-          ? none
+          ? util._extend({}, none)
           : util._extend(util._extend({}, d[key]), o[key])
       }
 


### PR DESCRIPTION
I have configuration where I call `st` multiple times, and following setup lead to errors:

```javascript
st({ path: '/some/public/path', cache: { fd: false } });
st({ path: '/some/public/path2', cache: false });
```
Problem is that with first call, internally reusable `none` object is modified:
https://github.com/isaacs/st/blob/master/st.js#L136
https://github.com/isaacs/st/blob/master/st.js#L157

With second _st_ intialization, `dispose` goes to all other caches, and that at some point crashes sever:

```
fs.js:465
  binding.close(fd, req);
          ^
TypeError: Bad argument
    at TypeError (native)
    at Object.fs.close (fs.js:465:11)
    at Object.close (/Users/medikoo/Projects/eregistrations/lomas/node_modules/graceful-fs/graceful-fs.js:37:19)
    at Object.cleanupFd (/Users/medikoo/Projects/eregistrations/lomas/node_modules/st/node_modules/fd/index.js:21:12)
    at Object.<anonymous> (/Users/medikoo/Projects/eregistrations/lomas/node_modules/st/node_modules/fd/index.js:35:21)
    at process._tickCallback (node.js:355:11)
```

It's caused by _stats_ objects from stat cache being provided to `dispose` of previous setup _fd_ cache.

I didn't provide test for it, as I'm not that familiar with current test setup, if it's something straightforward please guide and I'll add them.
