### PR TITLE
only consider url path for dotted files w/dot option

### DIFF
--- a/st.js
+++ b/st.js
@@ -237,7 +237,7 @@ Mount.prototype.serve = function (req, res, next) {
 
   // don't allow dot-urls by default, unless explicitly allowed.
   // If we got a 403, then it's explicitly forbidden.
-  if (p === 403 || !this.opt.dot && p.match(/(^|\/)\./)) {
+  if (p === 403 || !this.opt.dot && req.sturl.match(/(^|\/)\./)) {
     res.statusCode = 403
     res.end('Forbidden')
     return true

--- a/test/dot-common.js
+++ b/test/dot-common.js
@@ -1,0 +1,38 @@
+var path = require('path')
+var http = require('http')
+var request = require('request')
+var tap = require('tap')
+
+var st = require('../st.js')
+
+var port = process.env.PORT || 1337
+var test = exports.test = tap.test
+
+var server
+
+var opts = {
+  dot: global.dot,
+  path: path.join(__dirname, "fixtures", ".dotted-dir"),
+}
+
+var mount = st(opts)
+
+exports.req = function req (url, cb) {
+  request({ url: 'http://localhost:' + port + url }, cb)
+}
+
+test('setup', function (t) {
+  server = http.createServer(function (req, res) {
+    if (!mount(req, res)) {
+      res.statusCode = 404
+      return res.end('Not a match: ' + req.url)
+    }
+  }).listen(port, function () {
+    t.pass('listening')
+    t.end()
+  })
+})
+
+tap.tearDown(function() {
+  server.close()
+})

--- a/test/dot-false.js
+++ b/test/dot-false.js
@@ -1,0 +1,21 @@
+global.dot = false
+
+var common = require('./dot-common')
+
+var req = common.req
+var test = common.test
+
+// failing per https://github.com/isaacs/st/issues/67
+test('non-dotted file', function (t) {
+  req('/index.html', function (er, res, body) {
+    t.equal(res.statusCode, 200)
+    t.end()
+  })
+})
+
+test('dotted file', function (t) {
+  req('/.index.html', function (er, res, body) {
+    t.equal(res.statusCode, 403)
+    t.end()
+  })
+})

--- a/test/dot-true.js
+++ b/test/dot-true.js
@@ -1,0 +1,20 @@
+global.dot = true
+
+var common = require('./dot-common')
+
+var req = common.req
+var test = common.test
+
+test('non-dotted file', function (t) {
+  req('/index.html', function (er, res, body) {
+    t.equal(res.statusCode, 200)
+    t.end()
+  })
+})
+
+test('dotted file', function (t) {
+  req('/.index.html', function (er, res, body) {
+    t.equal(res.statusCode, 200)
+    t.end()
+  })
+})

--- a/test/fixtures/.dotted-dir/.index.html
+++ b/test/fixtures/.dotted-dir/.index.html
@@ -1,0 +1,11 @@
+<html>
+<head><title>Index of {url}</title></head>
+<body bgcolor="white">
+<h1>Index of {url}</h1><hr><pre><a href="../">../</a>
+<!-- dirs first -->
+<!-- for each show this:
+  <a href="{filename}">{filename}</a> {modified date}  {size}
+-->
+<!-- line up the fields nicely -->
+</pre><hr></body>
+</html>

--- a/test/fixtures/.dotted-dir/index.html
+++ b/test/fixtures/.dotted-dir/index.html
@@ -1,0 +1,11 @@
+<html>
+<head><title>Index of {url}</title></head>
+<body bgcolor="white">
+<h1>Index of {url}</h1><hr><pre><a href="../">../</a>
+<!-- dirs first -->
+<!-- for each show this:
+  <a href="{filename}">{filename}</a> {modified date}  {size}
+-->
+<!-- line up the fields nicely -->
+</pre><hr></body>
+</html>


### PR DESCRIPTION
For the dot option, st was searching the entire file name
when looking for dotted path components, instead of searching
the url path.

fixes #67