### PR TITLE
Avoid binding to all addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ Options:
 
 -p --port PORT        Listen on PORT (default=1337)
 
+-H --host HOST        Bind address HOST (default=*)
+
 -d --dir DIRECTORY    Serve the contents of DIRECTORY (default=cwd)
 
 -u --url MOUNTURL     Serve the contents at MOUNTURL mount path (default=/)
@@ -278,3 +280,7 @@ not, will be replaced with `'/'`.  If your application depends on url
 traversal, then you are encouraged to please refactor so that you do
 not depend on having `..` in url paths, as this tends to expose data
 that you may be surprised to be exposing.
+
+Consider using the `--host localhost` setting if you don't want other
+people on your local network to read the files served by the command
+line server.  This may become the default in a future major version.

--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ Options:
 
 -H --host HOST        Bind address HOST (default=*)
 
+-l --localhost        Same as "--host localhost"
+
 -d --dir DIRECTORY    Serve the contents of DIRECTORY (default=cwd)
 
 -u --url MOUNTURL     Serve the contents at MOUNTURL mount path (default=/)
@@ -281,6 +283,6 @@ traversal, then you are encouraged to please refactor so that you do
 not depend on having `..` in url paths, as this tends to expose data
 that you may be surprised to be exposing.
 
-Consider using the `--host localhost` setting if you don't want other
+Consider using the `--localhost` setting if you don't want other
 people on your local network to read the files served by the command
 line server.  This may become the default in a future major version.

--- a/bin/server.js
+++ b/bin/server.js
@@ -27,6 +27,11 @@ for (var i = 2; i < process.argv.length; i++) {
       }
       break
 
+    case '-l':
+    case '--localhost':
+      host = 'localhost'
+      break
+
     case '-d':
     case '--dir':
       dir = process.argv[++i]
@@ -107,6 +112,8 @@ function help () {
 ,'-p --port PORT        Listen on PORT (default=1337)'
 ,''
 ,'-H --host HOST        Bind address HOST (default=*)'
+,''
+,'-l --localhost        Same as "--host localhost"'
 ,''
 ,'-d --dir DIRECTORY    Serve the contents of DIRECTORY (default=cwd)'
 ,''

--- a/bin/server.js
+++ b/bin/server.js
@@ -156,6 +156,12 @@ http.createServer(function (q, s) {
   if (mount(q, s)) return
   s.statusCode = 404
   s.end('not found')
-}).listen(port)
-
-console.log('listening at http://127.0.0.1:' + port)
+}).listen(port, function() {
+  var addr = this.address()
+  var port = addr.port
+  var host = addr.address
+  if (/:/.test(host)) {
+    host = '[' + host + ']'
+  }
+  console.log('listening at http://' + host + ':' + port)
+})

--- a/bin/server.js
+++ b/bin/server.js
@@ -2,6 +2,7 @@
 var st = require('../st.js')
 var http = require('http')
 var port = +(process.env.PORT || 1337)
+var host = undefined
 var dir = ''
 var url = '/'
 var cacheSize = 0
@@ -16,6 +17,14 @@ for (var i = 2; i < process.argv.length; i++) {
     case '-p':
     case '--port':
       port = +(process.argv[++i])
+      break
+
+    case '-H':
+    case '--host':
+      host = process.argv[++i]
+      if (host === '*') {
+        host = undefined
+      }
       break
 
     case '-d':
@@ -97,6 +106,8 @@ function help () {
 ,''
 ,'-p --port PORT        Listen on PORT (default=1337)'
 ,''
+,'-H --host HOST        Bind address HOST (default=*)'
+,''
 ,'-d --dir DIRECTORY    Serve the contents of DIRECTORY (default=cwd)'
 ,''
 ,'-u --url /url         Serve at this mount url (default=/)'
@@ -156,10 +167,12 @@ http.createServer(function (q, s) {
   if (mount(q, s)) return
   s.statusCode = 404
   s.end('not found')
-}).listen(port, function() {
+}).listen(port, host, function() {
   var addr = this.address()
   var port = addr.port
-  var host = addr.address
+  if (!host) {
+    host = addr.address
+  }
   if (/:/.test(host)) {
     host = '[' + host + ']'
   }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "tap": "~2.3.1"
   },
   "scripts": {
-    "test": "tap test/*.js"
+    "test": "tap test/*.js test/cli/*-test.js"
   },
   "repository": {
     "type": "git",

--- a/test/cli/basic-test.js
+++ b/test/cli/basic-test.js
@@ -1,0 +1,37 @@
+var test = require('tap').test
+var common = require('./common')
+var serve = common.serve
+
+test('Basic cli operation', function (t) {
+  serve([], function (req) {
+
+    req('/st.js', function (er, res, body) {
+      t.ifError(er) &&
+      t.equal(res.statusCode, 200) &&
+      t.equal(body.toString(), common.stExpect)
+    })
+
+  }, function (er, stdout, stderr) {
+    t.ifError(er)
+    t.match(stdout, /^listening at http:\/\/(\[::\]|0\.0\.0\.0):[0-9]+\n$/)
+    t.equal(stderr, '')
+    t.end()
+  })
+})
+
+test('Listening on localhost only', function (t) {
+  serve(["--localhost"], function (req) {
+
+    req('/st.js', function (er, res, body) {
+      t.ifError(er) &&
+      t.equal(res.statusCode, 200) &&
+      t.equal(body.toString(), common.stExpect)
+    })
+
+  }, function (er, stdout, stderr) {
+    t.ifError(er)
+    t.match(stdout, /^listening at http:\/\/localhost:[0-9]+\n$/)
+    t.equal(stderr, '')
+    t.end()
+  })
+})

--- a/test/cli/common.js
+++ b/test/cli/common.js
@@ -1,0 +1,110 @@
+'use strict'
+
+var path = require('path')
+var fs = require('fs')
+var request = require('request')
+var child_process = require('child_process')
+var bl = require('bl')
+
+var port = process.env.PORT || 1337
+
+var server
+var stdout = bl()
+var stderr = bl()
+
+var stExpect = fs.readFileSync(require.resolve('../../st.js'), 'utf8')
+
+
+// Run server with given command line arguments,
+// then allow cbRequests to schedule a bunch of requests,
+// finally call cbDone.
+// cbRequests gets the req function as an argument.
+
+function serve (args, cbRequests, cbDone) {
+  args = [require.resolve('../../bin/server.js')].concat(args || [])
+  var server = child_process.spawn(process.execPath, args, {
+    cwd: path.dirname(path.dirname(__dirname)),
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: { LANG: 'C', LC_ALL: 'C' }
+  })
+  var stdout = bl()
+  var stderr = bl()
+  server.stdout.pipe(stdout)
+  server.stderr.pipe(stderr)
+  var thingsToDo = 4 // cbRequests, exit, stdout, stderr
+  var code = null
+  var signal = null
+  var cbReqEr = null
+  var outputSeen = false
+  server.once('error', function (er) {
+    thingsToDo = -10 // only call cbDone once
+    cbDone(er)
+  })
+  server.once('exit', function (c, s) {
+    code = c
+    signal = s
+    if (!outputSeen) {
+      outputSeen = true
+      --thingsToDo
+    }
+    then()
+  })
+  stdout.once('finish', then)
+  stderr.once('finish', then)
+  server.stdout.once('data', function () {
+    if (outputSeen) return
+    outputSeen = true
+    try {
+      cbRequests(req)
+    } catch (er) {
+      cbReqEr = er
+    } finally {
+      then()
+    }
+  })
+
+  function then () {
+    --thingsToDo
+    if (thingsToDo === 3) { // all requests done, one way or another
+      server.kill()
+    } else if (thingsToDo === 0) {
+      var er = null
+      if (cbReqEr)
+        er = cbReqEr
+      else if (signal !== null && signal !== 'SIGTERM')
+        er = Error("Terminated by signal " + signal)
+      else if (code !== null && code !== 0)
+        er = Error("Exited with code " + code)
+      var o = stdout.toString(), e = stderr.toString()
+      if (er) console.info(o), console.error(e)
+      cbDone(er, o, e)
+    }
+  }
+
+  function req (url, headers, cb) {
+    if (typeof headers === 'function') {
+      cb = headers
+      headers = {}
+    }
+    if (!/:\/\//.test(url)) {
+      url = 'http://localhost:' + port + url
+    }
+    ++thingsToDo
+    request({
+      encoding: null,
+      url: url,
+      headers: headers
+    }, function () {
+      try {
+        cb.apply(null, arguments)
+      } finally {
+        then()
+      }
+    })
+  }
+
+}
+
+module.exports.port = port
+module.exports.stExpect = stExpect
+module.exports.serve = serve

--- a/test/cli/host-test.js
+++ b/test/cli/host-test.js
@@ -1,0 +1,87 @@
+var os = require('os')
+var tap = require('tap')
+var test = tap.test
+var common = require('./common')
+var serve = common.serve
+
+var otherAddress = (function () {
+  var ifaces = os.networkInterfaces()
+  for (var iface in ifaces) {
+    var addrs = ifaces[iface]
+    for (var i = 0; i < addrs.length; ++i) {
+      var addr = addrs[i].address
+      if (/^127\./.test(addr) || /^::1$/.test(addr)) // loopback device
+        continue
+      if (/^fe80:/.test(addr)) // link-local address
+        continue
+      return addr
+    }
+  }
+  return null
+})()
+if (!otherAddress) {
+  tap.fail('No non-loopback network address found', {skip: true})
+  test = function () {}
+} else {
+  tap.comment('Using ' + otherAddress + ' as non-localhost address')
+}
+
+function addr2url (addr, path) {
+  if (/:/.test(addr)) addr = '[' + addr + ']'
+  addr = 'http://' + addr + ':' + common.port
+  if (path) addr += path
+  return addr
+}
+
+function testServer (name, args, addr, canConnect, cannotConnect) {
+  test(name, function (t) {
+    serve(args, function (req) {
+      canConnect.forEach(checkConnections(t, req, true))
+      cannotConnect.forEach(checkConnections(t, req, false))
+    }, function (err, stdout, stderr) {
+      t.ifError(err)
+      t.equal(stderr, '')
+      if (addr) {
+        t.equal(stdout, 'listening at ' + addr2url(addr) + '\n')
+      }
+      t.end()
+    })
+  })
+}
+
+function checkConnections (t, req, canConnect) {
+  return function (addr) {
+    var url = addr2url(addr, '/st.js')
+    req(url, function (er, res, body) {
+      if (canConnect) {
+        t.ifError(er, url) && t.equal(res.statusCode, 200, url)
+      } else {
+        t.ok(er, url)
+      }
+    })
+  }
+}
+
+testServer(
+  'Listening on all ports by default',
+  [], null,
+  ['127.0.0.1', 'localhost', otherAddress], []
+)
+
+testServer(
+  'Restricted to localhost',
+  ['--localhost'], 'localhost',
+  ['127.0.0.1', 'localhost'], [otherAddress]
+)
+
+testServer(
+  'Restricted to non-local host',
+  ['--host', otherAddress], otherAddress,
+  [otherAddress], ['127.0.0.1']
+)
+
+testServer(
+  'Restricted to IPv4',
+  ['--host', '127.0.0.1'], '127.0.0.1',
+  ['127.0.0.1'], ['::1']
+)


### PR DESCRIPTION
Always binding to all addresses, the way the command line server currently does, can be a security problem. The situation is made worse by the fact that the command line server tells the user only about listening on `127.0.0.1`, so the user may mistakenly think that only their local machine can access the server.

This pull request addresses these problems by making the host name configurable, by providing flags to only bind to `localhost`, and by always reporting the actual host name or address in the printed URL.

I would suggest changing the default host name to `localhost` in the next major version, so I suggested as much in the README. For now the change should be backwards-compatible, so I think a minor version bump would suffice.

I wrote these changes in three commits, addressing different aspects. Feel free to commit only some of them if you disagree with some of the later, e.g. if you don't want a `--localhost` flag. If you want me to, I can of course squash the commits.