### PR TITLE
Configure Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - node
+sudo: false


### PR DESCRIPTION
Currently Travis apparently tries to interpret all code as Ruby. With a `.travis.yml` indicating that we're dealing with a node module, we should be able to put the existing travis setup to some use. Hopefully this pull request here will already be marked as passing CI tests.