### PR TITLE
update mime dependency to avoid ReDoS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "async-cache": "~1.1.0",
     "bl": "~1.1.2",
     "fd": "~0.0.2",
-    "mime": "~1.3.4",
+    "mime": "~1.4.1",
     "negotiator": "~0.6.1"
   },
   "optionalDependencies": {


### PR DESCRIPTION
fixes issue https://github.com/isaacs/st/issues/90

Info on the vulnerability: https://snyk.io/vuln/npm:mime:20170907

Versions of mime < 1.4.1 are vulnerable.

Upgraded from ~1.3.4 to ~1.4.1