### PR TITLE
fix: change `nvm install current` to `nvm install node`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
   - '10'
   - '12'
   - lts/*
-  - current
+  - node
 branches:
   only:
     - master

--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
     "request": "^2.88.0",
     "rimraf": "^3.0.0",
     "standard": "^14.3.1",
-    "tap": "^14.9.2"
+    "tap": "^15.0.9"
   },
   "scripts": {
     "lint": "standard",
-    "test": "npm run lint && tap test/*.js test/cli/*-test.js"
+    "test": "npm run lint && tap test/*.js test/cli/*-test.js --no-coverage"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### 1: `Travis yml change`
`nvm install current` is deprecated, and instead, we need to use `nvm install node.`

The Travis CI is failing because of that. Any new pull requests in this project will fail in Travis's pipeline because of this change.

An example could be found here #93

I am keeping this PR separately to get track of why we changed this `yml` file.

Evidence:
![image](https://user-images.githubusercontent.com/26359740/118375960-c9ee3500-b5e2-11eb-9088-57fc1bddd5f6.png)


### 2: `tap` package upgraded
Also, the `tap` package version is upgraded. One of the dependencies of this package is internally resolving a module `'./reports/base'` that doesn't exist in the depending package.
Evidence:
![image](https://user-images.githubusercontent.com/26359740/118377396-9d3e1b80-b5ea-11eb-9eb9-cb28603987a0.png)


### 3: Pass`--no-coverage` flag with tests
The third change I added here is the `--coverage=false` or `--no coverage` flag in the `test` script. This is because, from the latest `tap` package, the test runner will fail if the coverage is less than 100%. Since we didn't trace the line metrics, instead just added the test cases for all the functionalities, it must be disabled. In the previous version, this flag is disabled by default. 