### PR TITLE
add `.nyc_output` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.nyc_output/


### PR DESCRIPTION
`.nyc_output` is showing too many file changes during the development. I hope these changes could ignore this in `.gitignore`