### PR TITLE
Replace deprecated `async-cache` with `lru-cache`

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ const mount = st({
     },
 
     content: {
-      max: 1024*1024*64, // how much memory to use on caching contents
+      maxSize: 1024*1024*64, // how much memory to use on caching contents
       maxAge: 1000 * 60 * 10, // how long to cache contents for
                               // if `false` does not set cache control headers
       cacheControl: 'public, max-age=600' // to set an explicit cache-control
@@ -137,12 +137,12 @@ const mount = st({
     },
 
     index: { // irrelevant if not using index:true
-      max: 1024 * 8, // how many bytes of autoindex html to cache
+      maxSize: 1024 * 8, // how many bytes of autoindex html to cache
       maxAge: 1000 * 60 * 10, // how long to store it for
     },
 
     readdir: { // irrelevant if not using index:true
-      max: 1000, // how many dir entries to cache
+      maxSize: 1000, // how many dir entries to cache
       maxAge: 1000 * 60 * 10, // how long to cache them for
     }
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "st.js",
   "bin": "bin/server.js",
   "dependencies": {
-    "async-cache": "^1.1.0",
+    "lru-cache": "^11.1.0",
     "bl": "^6.1.0",
     "fd": "^0.0.3",
     "mime": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "bl": "^6.1.0",
     "fd": "^0.0.3",
     "mime": "^3.0.0",
-    "negotiator": "^1.0.0",
-    "promisify": "^0.0.3"
+    "negotiator": "^1.0.0"
   },
   "optionalDependencies": {
     "graceful-fs": "^4.2.3"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "bl": "^6.1.0",
     "fd": "^0.0.3",
     "mime": "^3.0.0",
-    "negotiator": "^1.0.0"
+    "negotiator": "^1.0.0",
+    "promisify": "^0.0.3"
   },
   "optionalDependencies": {
     "graceful-fs": "^4.2.3"

--- a/st.js
+++ b/st.js
@@ -104,18 +104,6 @@ function st (opt) {
   return fn
 }
 
-const callbackToPromise = fun =>
-  key =>
-    new Promise((resolve, reject) =>
-      fun(key, (err, result) => {
-        if (err) {
-          reject(err)
-        } else {
-          resolve(result)
-        }
-      })
-    )
-
 class Mount {
   constructor (opt) {
     if (!opt) {
@@ -185,17 +173,12 @@ class Mount {
     }
 
     c.fd.dispose = key => this.fdman.close(key)
-    c.fd.fetchMethod = callbackToPromise((key, cb) => this.fdman.open(key, cb))
-    // c.fd.fetchMethod = promisify((key, cb) => this.fdman.open(key, cb))
+    c.fd.fetchMethod = key => new Promise((resolve, reject) => this.fdman.open(key, (err, fd) => err ? reject(err) : resolve(fd)))
 
-    // c.stat.fetchMethod = promisify((key, cb) => this._loadStat(key, cb))
-    // c.index.fetchMethod = promisify((key, cb) => this._loadIndex(key, cb))
-    // c.readdir.fetchMethod = promisify((key, cb) => this._loadReaddir(key, cb))
-    // c.content.fetchMethod = promisify((key, cb) => this._loadContent(key, cb))
-    c.stat.fetchMethod = callbackToPromise((key, cb) => this._loadStat(key, cb))
-    c.index.fetchMethod = callbackToPromise((key, cb) => this._loadIndex(key, cb))
-    c.readdir.fetchMethod = callbackToPromise((key, cb) => this._loadReaddir(key, cb))
-    c.content.fetchMethod = callbackToPromise((key, cb) => this._loadContent(key, cb))
+    c.stat.fetchMethod = key => new Promise((resolve, reject) => this._loadStat(key, (err, fd) => err ? reject(err) : resolve(fd)))
+    c.index.fetchMethod = key => new Promise((resolve, reject) => this._loadIndex(key, (err, fd) => err ? reject(err) : resolve(fd)))
+    c.readdir.fetchMethod = key => new Promise((resolve, reject) => this._loadReaddir(key, (err, fd) => err ? reject(err) : resolve(fd)))
+    c.content.fetchMethod = key => new Promise((resolve, reject) => this._loadContent(key, (err, fd) => err ? reject(err) : resolve(fd)))
 
     return c
   }

--- a/st.js
+++ b/st.js
@@ -172,13 +172,13 @@ class Mount {
       content: set('content')
     }
 
-    c.fd.dispose = key => this.fdman.close(key)
-    c.fd.fetchMethod = key => new Promise((resolve, reject) => this.fdman.open(key, (err, fd) => err ? reject(err) : resolve(fd)))
+    c.fd.dispose = (key) => this.fdman.close(key)
+    c.fd.fetchMethod = (key) => new Promise((resolve, reject) => this.fdman.open(key, (err, fd) => err ? reject(err) : resolve(fd)))
 
-    c.stat.fetchMethod = key => new Promise((resolve, reject) => this._loadStat(key, (err, fd) => err ? reject(err) : resolve(fd)))
-    c.index.fetchMethod = key => new Promise((resolve, reject) => this._loadIndex(key, (err, fd) => err ? reject(err) : resolve(fd)))
-    c.readdir.fetchMethod = key => new Promise((resolve, reject) => this._loadReaddir(key, (err, fd) => err ? reject(err) : resolve(fd)))
-    c.content.fetchMethod = key => new Promise((resolve, reject) => this._loadContent(key, (err, fd) => err ? reject(err) : resolve(fd)))
+    c.stat.fetchMethod = (key) => new Promise((resolve, reject) => this._loadStat(key, (err, fd) => err ? reject(err) : resolve(fd)))
+    c.index.fetchMethod = (key) => new Promise((resolve, reject) => this._loadIndex(key, (err, fd) => err ? reject(err) : resolve(fd)))
+    c.readdir.fetchMethod = (key) => new Promise((resolve, reject) => this._loadReaddir(key, (err, fd) => err ? reject(err) : resolve(fd)))
+    c.content.fetchMethod = (key) => new Promise((resolve, reject) => this._loadContent(key, (err, fd) => err ? reject(err) : resolve(fd)))
 
     return c
   }
@@ -274,7 +274,7 @@ class Mount {
 
     // now we have a path.  check for the fd.
     this.cache.fd.fetch(p).then(
-      fd => {
+      (fd) => {
         // we may be about to use this, so don't let it be closed by cache purge
         this.fdman.checkout(p, fd)
         // a safe end() function that can be called multiple times but
@@ -282,7 +282,7 @@ class Mount {
         const end = this.fdman.checkinfn(p, fd)
 
         this.cache.stat.fetch(fd + ':' + p).then(
-          stat => {
+          (stat) => {
             const isDirectory = stat.isDirectory()
 
             if (isDirectory) {
@@ -329,7 +329,7 @@ class Mount {
               ? this.index(p, req, res)
               : this.file(p, fd, stat, etag, req, res, end)
           },
-          er => {
+          (er) => {
             if (next && this.opt.passthrough === true && this._index === false) {
               return next()
             }
@@ -338,7 +338,7 @@ class Mount {
           }
         )
       },
-      er => {
+      (er) => {
         // inability to open is some kind of error, probably 404
         // if we're in passthrough, AND got a next function, we can
         // fall through to that.  otherwise, we already returned true,
@@ -395,13 +395,13 @@ class Mount {
 
     // promiseToCallback(this.cache.index.fetch(p), (er, html) => {
     this.cache.index.fetch(p).then(
-      html => {
+      (html) => {
         res.statusCode = 200
         res.setHeader('content-type', 'text/html')
         res.setHeader('content-length', html.length)
         res.end(html)
       },
-      er => this.error(er, res)
+      (er) => this.error(er, res)
     )
   }
 
@@ -535,7 +535,7 @@ class Mount {
       '<hr><pre><a href="../">../</a>\n'
 
     this.cache.readdir.fetch(p).then(
-      data => {
+      (data) => {
         let nameLen = 0
         let sizeLen = 0
 
@@ -582,7 +582,7 @@ class Mount {
         str += '</pre><hr></body></html>'
         cb(null, Buffer.from(str))
       },
-      er => cb(er)
+      (er) => cb(er)
     )
   }
 
@@ -605,14 +605,14 @@ class Mount {
       files.forEach((file) => {
         const pf = path.join(p, file)
         this.cache.stat.fetch(pf).then(
-          stat => {
+          (stat) => {
             if (stat.isDirectory()) {
               stat.size = '-'
             }
             data[file] = stat
             next()
           },
-          er => cb(er)
+          (er) => cb(er)
         )
       })
     })

--- a/st.js
+++ b/st.js
@@ -393,7 +393,6 @@ class Mount {
       return
     }
 
-    // promiseToCallback(this.cache.index.fetch(p), (er, html) => {
     this.cache.index.fetch(p).then(
       (html) => {
         res.statusCode = 200

--- a/test/no-cache.js
+++ b/test/no-cache.js
@@ -10,10 +10,10 @@ const { test } = require('tap')
 // additional tests to ensure that it's actually not caching.
 
 test('all caches should be empty', (t) => {
-  t.same(mount._this.cache.fd._cache.dump(), [])
-  t.same(mount._this.cache.stat._cache.dump(), [])
-  t.same(mount._this.cache.index._cache.dump(), [])
-  t.same(mount._this.cache.readdir._cache.dump(), [])
-  t.same(mount._this.cache.content._cache.dump(), [])
+  t.same(mount._this.cache.fd.dump(), [])
+  t.same(mount._this.cache.stat.dump(), [])
+  t.same(mount._this.cache.index.dump(), [])
+  t.same(mount._this.cache.readdir.dump(), [])
+  t.same(mount._this.cache.content.dump(), [])
   t.end()
 })


### PR DESCRIPTION
Fixes https://github.com/isaacs/st/issues/97

This pull request replaces the deprecated `async-cache` library with `lru-cache`.

I have converted the callbacks and promises in the code to keep the changes as small and isolated as possible.

See https://www.npmjs.com/package/async-cache and https://www.npmjs.com/package/lru-cache