### PR TITLE
Improve regular expression for removing trailing slashes

### DIFF
--- a/st.js
+++ b/st.js
@@ -216,9 +216,12 @@ class Mount {
 
   // get a path from a url
   getPath (u) {
-    // Normalise paths by removing trailing slashes
+    // Normalize paths by removing trailing slashes
     // This ensures consistent paths for directory content rendering
-    return path.join(this.path, u.replace(/(?<!\/)\/+$/, ''))
+    while (u.length > 0 && u[u.length - 1] === '/') {
+      u = u.slice(0, -1)
+    }
+    return path.join(this.path, u)
   }
 
   // get a url from a path

--- a/st.js
+++ b/st.js
@@ -216,10 +216,9 @@ class Mount {
 
   // get a path from a url
   getPath (u) {
-    // trailing slash removal to fix Node.js v23 bug
-    // https://github.com/nodejs/node/pull/55527
-    // can be removed when this is resolved and released
-    return path.join(this.path, u.replace(/\/+$/, ''))
+    // Normalise paths by removing trailing slashes
+    // This ensures consistent paths for directory content rendering
+    return path.join(this.path, u.replace(/(?<!\/)\/+$/, ''))
   }
 
   // get a url from a path


### PR DESCRIPTION
Update the regular expression that is used to remove trailing slashes from the path in `Mount#getPath` - introduced in #98 - to avoid super-linear runtimes[^1]. I believe this does not affect the `st` export because the only path to this API is through `Mount#serve` which sanitizes the `req.url` using `path.normalize` (in `Mount#getUriPath`). However, the `Mount` class is also exported directly, through which `getPath` could be called on unsanitized inputs.

The super-linear runtime could occur because the regex engine will backtrack through a repetition of '/'s if it is not at the end. This is resolved by anchoring a repetition '/' on a non-'/' with a negative lookbehind.

The issue can be tested and reproduced using this script:

```js
const st = require('st')
const path = require('path')
const mount = new st.Mount({
  path: path.join(__dirname, '/static'),
  url: '/static'
})

for (let i = 0; i < 90_000; i += 10_000) {
  console.time('timer')
  mount.getPath(`a${"/".repeat(i)}a`)
  console.timeEnd('timer')
}
```

[^1]: while some consider this an availability problem, I decided to contribute this update in the open because 1) it only affects an undocumented API, and 2) this project lacks a security policy.