### PR TITLE
fix: decode percent-encoded paths before the traversal check

### DIFF
--- a/st.js
+++ b/st.js
@@ -187,28 +187,30 @@ class Mount {
   getUriPath (u) {
     let p = new URL(u, 'http://base').pathname
 
+    // Percent-decode before checking for `..` segments. The URL parser only
+    // resolves dot-segments that appear literally in the pathname, so an
+    // encoded separator (e.g. `/..%2f..%2fsecret`) keeps the `..` hidden and
+    // sails past the traversal check below until it is decoded. Decoding first
+    // means the check, and `path.normalize` after it, see the real path.
+    try {
+      const decoded = decodeURIComponent(p)
+      if (decoded !== p) {
+        p = decoded
+      }
+    } catch (e) {
+      // not a valid url-encoded path, so we can't safely serve it
+      return false
+    }
+
     // Convert any backslashes to forward slashes (for consistency)
     p = p.replace(/\\/g, '/')
 
-    // Remove the redundant leading slash replacement - URL().pathname always starts with /
     if ((/[/\\]\.\.([/\\]|$)/).test(p)) {
       return 403
     }
 
     u = path.normalize(p).replace(/\\/g, '/')
     if (u.indexOf(this.url) !== 0) {
-      return false
-    }
-
-    // URL constructor already decoded, but we might need additional decoding
-    // for edge cases. Only do it if it would actually change something.
-    try {
-      const decoded = decodeURIComponent(u)
-      if (decoded !== u) {
-        u = decoded
-      }
-    } catch (e) {
-      // if decodeURIComponent failed, we weren't given a valid URL to begin with.
       return false
     }
 

--- a/test/encoded-traversal.js
+++ b/test/encoded-traversal.js
@@ -1,0 +1,27 @@
+global.dot = true
+
+const { test } = require('tap')
+const { req } = require('./dot-common')
+
+// A percent-encoded separator must not smuggle a `..` past the traversal
+// guard. `..%2f` (and `..%5c`) only decode to `../` after the path has been
+// checked, so the check has to run on the decoded path. `dot: true` is needed
+// to reach this: with the default `dot: false`, the decoded `..` is rejected
+// independently as a dot-url. `space in filename.txt` lives in the parent of
+// the served root, so a non-403 here would mean the response left the mount.
+
+test('encoded-slash parent traversal is forbidden', (t) => {
+  req('/..%2fspace%20in%20filename.txt', (er, res, body) => {
+    t.error(er)
+    t.equal(res.statusCode, 403)
+    t.end()
+  })
+})
+
+test('encoded-backslash parent traversal is forbidden', (t) => {
+  req('/..%5cspace%20in%20filename.txt', (er, res, body) => {
+    t.error(er)
+    t.equal(res.statusCode, 403)
+    t.end()
+  })
+})


### PR DESCRIPTION
`getUriPath()` checks for `..` segments against the URL pathname and only percent-decodes afterwards. The URL parser resolves `.` and `..` only when they appear literally, so a request like `/..%2f..%2fsecret` keeps its separators encoded and gets past the check. The `decodeURIComponent` call lower down then turns `%2f` back into `/`, so the path that reaches `getPath()` is `/../../secret` and `path.join` walks out of the served root.

With the default `dot: false` this happens to be caught: the decoded path starts a segment with `.`, and `serve()` rejects dot-urls. But with `dot: true` (for example when serving `.well-known/`) that filter is off, and the request reads files above the mount.

Repro with `dot: true`, serving a directory whose parent holds `secret.txt`:

```
GET /..%2fsecret.txt   ->  200, body is the parent's secret.txt
GET /../secret.txt     ->  404, the literal .. is normalized away by the URL parser
```

The change moves the decode to the top of `getUriPath()`, so the `..` check and the following `path.normalize` both see the real path. This is the order `send` uses (decode, then `UP_PATH_REGEXP`). Encoded backslashes (`%5c`) are covered too, since the existing `\` to `/` step now runs after decoding.

`test/encoded-traversal.js` mounts a fixtures dir with `dot: true` and asserts that `/..%2f<file in parent>` and `/..%5c<file in parent>` return 403. It returns 200 on the current code and 403 with this change. The rest of the suite is unchanged.
