### PR TITLE
fix: decode percent-encoded paths before the traversal check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Use Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
       - name: Install Dependencies

--- a/st.js
+++ b/st.js
@@ -61,6 +61,17 @@ const noCaching = {
   content: none
 }
 
+const noCache = (fetch) => {
+  return {
+    maxSize: 0,
+    fetch,
+    has: () => false,
+    get: () => undefined,
+    set: () => {},
+    dump: () => []
+  }
+}
+
 function st (opt) {
   let p, u
   if (typeof opt === 'string') {
@@ -129,11 +140,11 @@ class Mount {
     // cache basically everything
     const c = this.getCacheOptions(opt)
     this.cache = {
-      fd: new LRUCache(c.fd),
-      stat: new LRUCache(c.stat),
-      index: new LRUCache(c.index),
-      readdir: new LRUCache(c.readdir),
-      content: new LRUCache(c.content)
+      fd: c.fd.noCache ? noCache(c.fd.fetchMethod) : new LRUCache(c.fd),
+      stat: c.stat.noCache ? noCache(c.stat.fetchMethod) : new LRUCache(c.stat),
+      index: c.index.noCache ? noCache(c.index.fetchMethod) : new LRUCache(c.index),
+      readdir: c.readdir.noCache ? noCache(c.readdir.fetchMethod) : new LRUCache(c.readdir),
+      content: c.content.noCache ? noCache(c.content.fetchMethod) : new LRUCache(c.content)
     }
 
     this._cacheControl =
@@ -150,7 +161,7 @@ class Mount {
     let o = opt.cache
     const set = (key) => {
       return o[key] === false
-        ? Object.assign({}, none)
+        ? Object.assign({ noCache: true }, none)
         : Object.assign(Object.assign({}, d[key]), o[key])
     }
 
@@ -172,7 +183,7 @@ class Mount {
       content: set('content')
     }
 
-    c.fd.dispose = (key) => this.fdman.close(key)
+    c.fd.dispose = (fd, key) => this.fdman.close(key, fd)
     c.fd.fetchMethod = (key) => new Promise((resolve, reject) => this.fdman.open(key, (err, fd) => err ? reject(err) : resolve(fd)))
 
     c.stat.fetchMethod = (key) => new Promise((resolve, reject) => this._loadStat(key, (err, fd) => err ? reject(err) : resolve(fd)))

--- a/st.js
+++ b/st.js
@@ -193,10 +193,7 @@ class Mount {
     // sails past the traversal check below until it is decoded. Decoding first
     // means the check, and `path.normalize` after it, see the real path.
     try {
-      const decoded = decodeURIComponent(p)
-      if (decoded !== p) {
-        p = decoded
-      }
+      p = decodeURIComponent(p)
     } catch (e) {
       // not a valid url-encoded path, so we can't safely serve it
       return false
@@ -205,18 +202,22 @@ class Mount {
     // Convert any backslashes to forward slashes (for consistency)
     p = p.replace(/\\/g, '/')
 
-    if ((/[/\\]\.\.([/\\]|$)/).test(p)) {
+    if ((/(^|\/)\.\.(\/|$)/).test(p)) {
       return 403
     }
 
     u = path.normalize(p).replace(/\\/g, '/')
-    if (u.indexOf(this.url) !== 0) {
+    const prefix = this.url.endsWith('/') ? this.url : this.url + '/'
+    if (this.url !== '/' && u !== this.url && u.indexOf(prefix) !== 0) {
       return false
     }
 
     u = u.substr(this.url.length)
     if (u.charAt(0) !== '/') {
       u = '/' + u
+    }
+    if ((/(^|\/)\.\.(\/|$)/).test(u)) {
+      return 403
     }
 
     return u
@@ -229,7 +230,14 @@ class Mount {
     while (u.length > 0 && u[u.length - 1] === '/') {
       u = u.slice(0, -1)
     }
-    return path.join(this.path, u)
+
+    const p = path.resolve(this.path, '.' + u)
+    const rel = path.relative(this.path, p)
+    if (rel === '..' || rel.indexOf('..' + path.sep) === 0 || path.isAbsolute(rel)) {
+      return 403
+    }
+
+    return p
   }
 
   // get a url from a path
@@ -275,6 +283,11 @@ class Mount {
     }
 
     const p = this.getPath(req.sturl)
+    if (p === 403) {
+      res.statusCode = 403
+      res.end(STATUS_CODES[res.statusCode])
+      return true
+    }
 
     // now we have a path.  check for the fd.
     this.cache.fd.fetch(p).then(

--- a/st.js
+++ b/st.js
@@ -187,28 +187,30 @@ class Mount {
   getUriPath (u) {
     let p = new URL(u, 'http://base').pathname
 
+    // Percent-decode before checking for `..` segments. The URL parser only
+    // resolves dot-segments that appear literally in the pathname, so an
+    // encoded separator (e.g. `/..%2f..%2fsecret`) keeps the `..` hidden and
+    // sails past the traversal check below until it is decoded. Decoding first
+    // means the check, and `path.normalize` after it, see the real path.
+    try {
+      const decoded = decodeURIComponent(p)
+      if (decoded !== p) {
+        p = decoded
+      }
+    } catch (e) {
+      // not a valid url-encoded path, so we can't safely serve it
+      return false
+    }
+
     // Convert any backslashes to forward slashes (for consistency)
     p = p.replace(/\\/g, '/')
 
-    // Remove the redundant leading slash replacement - URL().pathname always starts with /
     if ((/[/\\]\.\.([/\\]|$)/).test(p)) {
       return 403
     }
 
     u = path.normalize(p).replace(/\\/g, '/')
     if (u.indexOf(this.url) !== 0) {
-      return false
-    }
-
-    // URL constructor already decoded, but we might need additional decoding
-    // for edge cases. Only do it if it would actually change something.
-    try {
-      const decoded = decodeURIComponent(u)
-      if (decoded !== u) {
-        u = decoded
-      }
-    } catch (e) {
-      // if decodeURIComponent failed, we weren't given a valid URL to begin with.
       return false
     }
 

--- a/test/dot-common.js
+++ b/test/dot-common.js
@@ -10,6 +10,7 @@ let server
 
 const opts = {
   dot: global.dot,
+  url: global.url,
   path: path.join(__dirname, 'fixtures', '.dotted-dir')
 }
 

--- a/test/encoded-traversal.js
+++ b/test/encoded-traversal.js
@@ -1,7 +1,9 @@
 global.dot = true
 
+const path = require('path')
 const { test } = require('tap')
 const { req } = require('./dot-common')
+const st = require('../st.js')
 
 // A percent-encoded separator must not smuggle a `..` past the traversal
 // guard. `..%2f` (and `..%5c`) only decode to `../` after the path has been
@@ -24,4 +26,14 @@ test('encoded-backslash parent traversal is forbidden', (t) => {
     t.equal(res.statusCode, 403)
     t.end()
   })
+})
+
+test('resolved paths cannot leave the root', (t) => {
+  const mount = st({
+    dot: true,
+    path: path.join(__dirname, 'fixtures', '.dotted-dir')
+  })._this
+
+  t.equal(mount.getPath('/../space in filename.txt'), 403)
+  t.end()
 })

--- a/test/encoded-traversal.js
+++ b/test/encoded-traversal.js
@@ -1,0 +1,27 @@
+global.dot = true
+
+const { test } = require('tap')
+const { req } = require('./dot-common')
+
+// A percent-encoded separator must not smuggle a `..` past the traversal
+// guard. `..%2f` (and `..%5c`) only decode to `../` after the path has been
+// checked, so the check has to run on the decoded path. `dot: true` is needed
+// to reach this: with the default `dot: false`, the decoded `..` is rejected
+// independently as a dot-url. `space in filename.txt` lives in the parent of
+// the served root, so a non-403 here would mean the response left the mount.
+
+test('encoded-slash parent traversal is forbidden', (t) => {
+  req('/..%2fspace%20in%20filename.txt', (er, res, body) => {
+    t.error(er)
+    t.equal(res.statusCode, 403)
+    t.end()
+  })
+})
+
+test('encoded-backslash parent traversal is forbidden', (t) => {
+  req('/..%5cspace%20in%20filename.txt', (er, res, body) => {
+    t.error(er)
+    t.equal(res.statusCode, 403)
+    t.end()
+  })
+})

--- a/test/mounted-encoded-traversal.js
+++ b/test/mounted-encoded-traversal.js
@@ -1,0 +1,46 @@
+global.dot = true
+global.url = '/static'
+
+const { test } = require('tap')
+const { req } = require('./dot-common')
+
+// Non-root mounts need a segment-boundary check before stripping the mount
+// prefix. Otherwise `/static..%2fsecret` can pass validation as
+// `/static../secret`, then become `/../secret` after the `/static` prefix is
+// removed.
+
+test('mounted encoded-slash prefix traversal is not a match', (t) => {
+  req('/static..%2fspace%20in%20filename.txt', (er, res, body) => {
+    t.error(er)
+    t.equal(res.statusCode, 404)
+    t.notMatch(body, /space in filename/)
+    t.end()
+  })
+})
+
+test('mounted encoded-dot prefix traversal is not a match', (t) => {
+  req('/static%2e%2e%2fspace%20in%20filename.txt', (er, res, body) => {
+    t.error(er)
+    t.equal(res.statusCode, 404)
+    t.notMatch(body, /space in filename/)
+    t.end()
+  })
+})
+
+test('mounted encoded-backslash prefix traversal is not a match', (t) => {
+  req('/static..%5cspace%20in%20filename.txt', (er, res, body) => {
+    t.error(er)
+    t.equal(res.statusCode, 404)
+    t.notMatch(body, /space in filename/)
+    t.end()
+  })
+})
+
+test('mounted encoded traversal inside the mount is forbidden', (t) => {
+  req('/static/..%2fspace%20in%20filename.txt', (er, res, body) => {
+    t.error(er)
+    t.equal(res.statusCode, 403)
+    t.notMatch(body, /space in filename/)
+    t.end()
+  })
+})


### PR DESCRIPTION
Pulls in https://github.com/isaacs/st/pull/104 and goes a bit further with a second commit because mount matching also comes in to play and needs to be accounted for here.

Thanks @greymoth-jp for finding this. Also @oc-6f6f41 for reporting it via email independently.